### PR TITLE
Tweaked the file name check to only make sure the name includes Jenkinsfile and isnt equal to it

### DIFF
--- a/Jenkinsfile.py
+++ b/Jenkinsfile.py
@@ -50,7 +50,7 @@ if sublime.platform() == 'windows':
 class JenkinsfileCommand(sublime_plugin.TextCommand):
   def run(self, edit):
     view = self.view
-    if os.path.basename(view.file_name()) == 'Jenkinsfile':
+    if 'Jenkinsfile' in os.path.basename(view.file_name()):
       view = self.view
       view.erase_phantoms('alerts')
       jenkinsfileRegion = sublime.Region(0, view.size())


### PR DESCRIPTION
Hi! In some projects we have multiple Jenkinsfiles for different pipelines so this change is very useful for us.